### PR TITLE
Adicionando python-decouple

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Utilzamos o SGBD MariaDB/MySql.
 sudo apt install python3-dev default-libmysqlclient-dev
 ```
 
-### Virtualenv e variáveis de ambiente
+## Virtualenv e variáveis de ambiente
 
 Adicionar em ~/.profile as variáveis de ambiente:
 
@@ -65,6 +65,18 @@ Para desativar: ```deactivate```.
 ```shell script
 pip install -r requirements.txt
 ```
+
+## Ocultando a instância de configuração
+
+* Crie um arquivo .env na raiz do projeto e insira as seguintes variáveis.
+* SECRET_KEY=Sua$eCretKeyAqui (Pegue a secret key no arquivo settings.py)
+* DEBUG=True
+
+## Settings.py
+
+* from decouple import config
+* SECRET_KEY = config('SECRET_KEY')
+* DEBUG = config('DEBUG', default=False, cast=bool)
 
 ## Migrations
 

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -15,6 +15,7 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import sys
 from django.contrib.messages import constants as messages
+from decouple import config
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -24,12 +25,14 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 # SECRET_KEY = 'cg#p$g+j9tax!#a3cup@1$8obt2_+&k3q+pmu)5%asj6yjpkag'
 # SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
-SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
+#SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
+SECRET_KEY = config('SECRET_KEY')
 print(SECRET_KEY)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # DEBUG = True
-DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
+# DEBUG = os.environ.get('DJANGO_DEBUG', '') != 'False'
+DEBUG = config('DEBUG', default=False, cast=bool)
 print(os.environ.get('DJANGO_SETTINGS_MODULE'))
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'testserver']

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ pytest~=5.4.1
 
 django-debug-toolbar==2.2
 dj-database-url==0.5.0
+
+python-decouple


### PR DESCRIPTION
Foi feito a adicção da lib python-decouple para que possamos isolar a Sercret Key.
Foi alterado a o README.md com instruções de como usar o python-decouple.
Foi alterado o settings.py para usar o python-decouple na Secret Key e no Debug.